### PR TITLE
Add and load FactoryGirl config with RSpec

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -6,7 +6,9 @@ abort("The Rails environment is running in production mode!") if Rails.env.produ
 require 'support/simplecov'
 require 'spec_helper'
 require 'rspec/rails'
+
 # Add additional requires below this line. Rails is not loaded until this point!
+require 'support/factory_girl'
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are

--- a/spec/support/factory_girl.rb
+++ b/spec/support/factory_girl.rb
@@ -1,0 +1,3 @@
+RSpec.configure do |config|
+  config.include FactoryGirl::Syntax::Methods
+end


### PR DESCRIPTION
This PR fixes an error that occurs while trying to use FactoryGirl methods directly in rspec tests (NoMethodError). Before that we needed to use FactoryGirl.method_name to use FactoryGirl, after this PR we can use them directly.