### PR TITLE
Add Pokemon and Alola Form models validations plus minor .editorconfig change

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,3 +5,4 @@ indent_style = space
 indent_size = 2
 end_of_line = lf
 insert_final_newline = true
+trim_trailing_whitespace = true

--- a/app/models/alola_form.rb
+++ b/app/models/alola_form.rb
@@ -5,4 +5,13 @@ class AlolaForm < ApplicationRecord
   belongs_to :ability_1, class_name: Ability, foreign_key: :ability_1_id
   belongs_to :ability_2, optional: true, class_name: Ability, foreign_key: :ability_1_id
   belongs_to :hidden_ability, class_name: Ability, foreign_key: :hidden_ability_id
+
+  # validations
+  validates :height, presence: true, numericality: true
+  validates :weight, presence: true, numericality: true
+  validates :attack, presence: true, numericality: { only_integer: true }
+  validates :defense, presence: true, numericality: { only_integer: true }
+  validates :sp_attack, presence: true, numericality: { only_integer: true }
+  validates :sp_defense, presence: true, numericality: { only_integer: true }
+  validates :speed, presence: true, numericality: { only_integer: true }
 end

--- a/app/models/pokemon.rb
+++ b/app/models/pokemon.rb
@@ -4,4 +4,22 @@ class Pokemon < ApplicationRecord
   belongs_to :ability_1, class_name: Ability, foreign_key: :ability_1_id
   belongs_to :ability_2, optional: true, class_name: Ability, foreign_key: :ability_1_id
   belongs_to :hidden_ability, class_name: Ability, foreign_key: :hidden_ability_id
+
+  # validations
+  validates :id, presence: true, numericality: { only_integer: true }
+  validates :name, presence: true
+  validates :classification, presence: true
+  validates :height, presence: true, numericality: true
+  validates :weight, presence: true, numericality: true
+  validates :capture_rate, presence: true, numericality: { only_integer: true }
+  validates :base_egg_steps, presence: true, numericality: { only_integer: true }
+  validates :male_gender_ratio, presence: true, numericality: true
+  validates :experience_growth, presence: true, numericality: { only_integer: true }
+  validates :base_happiness, presence: true, numericality: { only_integer: true }
+  validates :hp, presence: true, numericality: { only_integer: true }
+  validates :attack, presence: true, numericality: { only_integer: true }
+  validates :defense, presence: true, numericality: { only_integer: true }
+  validates :sp_attack, presence: true, numericality: { only_integer: true }
+  validates :sp_defense, presence: true, numericality: { only_integer: true }
+  validates :speed, presence: true, numericality: { only_integer: true }
 end

--- a/spec/factories/alola_forms.rb
+++ b/spec/factories/alola_forms.rb
@@ -1,4 +1,17 @@
 FactoryGirl.define do
   factory :alola_form do
+    association :pokemon, factory: :pokemon
+    association :type_1, factory: :type
+    association :type_2, factory: :type
+    association :ability_1, factory: :ability
+    association :ability_2, factory: :ability
+    association :hidden_ability, factory: :ability
+    height 10.0
+    weight 10.0
+    attack 10
+    defense 10
+    sp_attack 10
+    sp_defense 10
+    speed 3
   end
 end

--- a/spec/factories/pokemons.rb
+++ b/spec/factories/pokemons.rb
@@ -1,8 +1,8 @@
 FactoryGirl.define do
   factory :pokemon do
-    add_attribute(:id) { 1 }
-    add_attribute(:name) { "Bulbasaur Pokemon Test" }
-    classification "Bulbasaur Test"
+    sequence(:id) { |n| n }
+    sequence(:name) { |n| "pokemon_#{n}_test" }
+    sequence(:classification) { |n| "Pokemon #{n} Test" }
     height 13
     weight 13
     capture_rate 10

--- a/spec/factories/pokemons.rb
+++ b/spec/factories/pokemons.rb
@@ -1,4 +1,25 @@
 FactoryGirl.define do
   factory :pokemon do
+    add_attribute(:id) { 1 }
+    add_attribute(:name) { "Bulbasaur Pokemon Test" }
+    classification "Bulbasaur Test"
+    height 13
+    weight 13
+    capture_rate 10
+    base_egg_steps 3
+    male_gender_ratio 13.3
+    experience_growth 1_000_300
+    base_happiness 300
+    hp 13_000
+    attack 100
+    defense 100
+    sp_attack 200
+    sp_defense 150
+    speed 5
+    association :type_1, factory: :type
+    association :type_2, factory: :type
+    association :ability_1, factory: :ability
+    association :ability_2, factory: :ability
+    association :hidden_ability, factory: :ability
   end
 end

--- a/spec/models/alola_form_spec.rb
+++ b/spec/models/alola_form_spec.rb
@@ -1,5 +1,85 @@
 require 'rails_helper'
 
 RSpec.describe AlolaForm, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  it "must be valid with valid attributes" do
+    alola_form = build(:alola_form)
+    expect(alola_form).to be_valid
+  end
+
+  it 'must have decimal or integer height' do
+    alola_form = build(:alola_form, height: 'Height')
+    expect(alola_form).to be_invalid
+
+    alola_form = build(:alola_form, height: 1)
+    expect(alola_form).to be_valid
+
+    alola_form = build(:alola_form, height: 1.1)
+    expect(alola_form).to be_valid
+  end
+
+  it 'must have decimal or integer weight' do
+    alola_form = build(:alola_form, weight: 'Weight')
+    expect(alola_form).to be_invalid
+
+    alola_form = build(:alola_form, weight: 1)
+    expect(alola_form).to be_valid
+
+    alola_form = build(:alola_form, weight: 1.1)
+    expect(alola_form).to be_valid
+  end
+
+  it 'must have integer attack' do
+    alola_form = build(:alola_form, attack: 'Attack')
+    expect(alola_form).to be_invalid
+
+    alola_form = build(:alola_form, attack: 1.1)
+    expect(alola_form).to be_invalid
+
+    alola_form = build(:alola_form, attack: 1)
+    expect(alola_form).to be_valid
+  end
+
+  it 'must have integer defense' do
+    alola_form = build(:alola_form, defense: 'Defense')
+    expect(alola_form).to be_invalid
+
+    alola_form = build(:alola_form, defense: 1.1)
+    expect(alola_form).to be_invalid
+
+    alola_form = build(:alola_form, defense: 1)
+    expect(alola_form).to be_valid
+  end
+
+  it 'must have integer sp_attack' do
+    alola_form = build(:alola_form, sp_attack: 'SP Attack')
+    expect(alola_form).to be_invalid
+
+    alola_form = build(:alola_form, sp_attack: 1.1)
+    expect(alola_form).to be_invalid
+
+    alola_form = build(:alola_form, sp_attack: 1)
+    expect(alola_form).to be_valid
+  end
+
+  it 'must have integer sp_defense' do
+    alola_form = build(:alola_form, sp_defense: 'SP Defense')
+    expect(alola_form).to be_invalid
+
+    alola_form = build(:alola_form, sp_defense: 1.1)
+    expect(alola_form).to be_invalid
+
+    alola_form = build(:alola_form, sp_defense: 1)
+    expect(alola_form).to be_valid
+  end
+
+  it 'must have integer speed' do
+    alola_form = build(:alola_form, speed: 'Speed')
+    expect(alola_form).to be_invalid
+
+    alola_form = build(:alola_form, speed: 1.1)
+    expect(alola_form).to be_invalid
+
+    alola_form = build(:alola_form, speed: 1)
+    expect(alola_form).to be_valid
+  end
 end

--- a/spec/models/pokemon_spec.rb
+++ b/spec/models/pokemon_spec.rb
@@ -1,5 +1,178 @@
 require 'rails_helper'
 
 RSpec.describe Pokemon, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  it 'must be valid with valid attributes' do
+    pokemon = build(:pokemon)
+    expect(pokemon).to be_valid
+  end
+
+  it 'must have integer id' do
+    pokemon = build(:pokemon, id: 'String ID')
+    expect(pokemon).to be_invalid
+
+    pokemon = build(:pokemon, id: 1.1)
+    expect(pokemon).to be_invalid
+
+    pokemon = build(:pokemon, id: 1)
+    expect(pokemon).to be_valid
+  end
+
+  it 'must have name' do
+    pokemon = build(:pokemon, name: 'Test Name')
+    expect(pokemon).to be_valid
+
+    pokemon = build(:pokemon, name: '')
+    expect(pokemon).to be_invalid
+  end
+
+  it 'must have classification' do
+    pokemon = build(:pokemon, classification: 'Test Classification')
+    expect(pokemon).to be_valid
+
+    pokemon = build(:pokemon, classification: '')
+    expect(pokemon).to be_invalid
+  end
+
+  it 'must have decimal or integer height' do
+    pokemon = build(:pokemon, height: 'Height')
+    expect(pokemon).to be_invalid
+
+    pokemon = build(:pokemon, height: 1)
+    expect(pokemon).to be_valid
+    
+    pokemon = build(:pokemon, height: 1.1)
+    expect(pokemon).to be_valid
+  end
+
+  it 'must have decimal or integer weight' do
+    pokemon = build(:pokemon, weight: 'Weight')
+    expect(pokemon).to be_invalid
+
+    pokemon = build(:pokemon, weight: 1)
+    expect(pokemon).to be_valid
+    
+    pokemon = build(:pokemon, weight: 1.1)
+    expect(pokemon).to be_valid
+  end
+
+  it 'must have integer capture rate' do
+    pokemon = build(:pokemon, capture_rate: 'Capture Rate')
+    expect(pokemon).to be_invalid
+
+    pokemon = build(:pokemon, capture_rate: 1.1)
+    expect(pokemon).to be_invalid
+
+    pokemon = build(:pokemon, capture_rate: 1)
+    expect(pokemon).to be_valid
+  end
+
+  it 'must have integer base egg steps' do
+    pokemon = build(:pokemon, base_egg_steps: 'Base Egg Steps')
+    expect(pokemon).to be_invalid
+
+    pokemon = build(:pokemon, base_egg_steps: 1.1)
+    expect(pokemon).to be_invalid
+
+    pokemon = build(:pokemon, base_egg_steps: 1)
+    expect(pokemon).to be_valid
+  end
+
+  it 'must have decimal or integer male_gender_ratio' do
+    pokemon = build(:pokemon, male_gender_ratio: 'Male Gender Ratio')
+    expect(pokemon).to be_invalid
+
+    pokemon = build(:pokemon, male_gender_ratio: 1)
+    expect(pokemon).to be_valid
+    
+    pokemon = build(:pokemon, male_gender_ratio: 1.1)
+    expect(pokemon).to be_valid
+  end
+
+  it 'must have integer experience_growth' do
+    pokemon = build(:pokemon, experience_growth: 'Experience Growth')
+    expect(pokemon).to be_invalid
+
+    pokemon = build(:pokemon, experience_growth: 1.1)
+    expect(pokemon).to be_invalid
+
+    pokemon = build(:pokemon, experience_growth: 1)
+    expect(pokemon).to be_valid
+  end
+
+  it 'must have integer base_happiness' do
+    pokemon = build(:pokemon, base_happiness: 'Base Happiness')
+    expect(pokemon).to be_invalid
+
+    pokemon = build(:pokemon, base_happiness: 1.1)
+    expect(pokemon).to be_invalid
+
+    pokemon = build(:pokemon, base_happiness: 1)
+    expect(pokemon).to be_valid
+  end
+
+  it 'must have integer hp' do
+    pokemon = build(:pokemon, hp: 'HP')
+    expect(pokemon).to be_invalid
+
+    pokemon = build(:pokemon, hp: 1.1)
+    expect(pokemon).to be_invalid
+
+    pokemon = build(:pokemon, hp: 1)
+    expect(pokemon).to be_valid
+  end
+
+  it 'must have integer attack' do
+    pokemon = build(:pokemon, attack: 'Attack')
+    expect(pokemon).to be_invalid
+
+    pokemon = build(:pokemon, attack: 1.1)
+    expect(pokemon).to be_invalid
+
+    pokemon = build(:pokemon, attack: 1)
+    expect(pokemon).to be_valid
+  end
+
+  it 'must have integer defense' do
+    pokemon = build(:pokemon, defense: 'Defense')
+    expect(pokemon).to be_invalid
+
+    pokemon = build(:pokemon, defense: 1.1)
+    expect(pokemon).to be_invalid
+
+    pokemon = build(:pokemon, defense: 1)
+    expect(pokemon).to be_valid
+  end
+
+  it 'must have integer sp_attack' do
+    pokemon = build(:pokemon, sp_attack: 'SP Attack')
+    expect(pokemon).to be_invalid
+
+    pokemon = build(:pokemon, sp_attack: 1.1)
+    expect(pokemon).to be_invalid
+
+    pokemon = build(:pokemon, sp_attack: 1)
+    expect(pokemon).to be_valid
+  end
+
+  it 'must have integer sp_defense' do
+    pokemon = build(:pokemon, sp_defense: 'SP Defense')
+    expect(pokemon).to be_invalid
+
+    pokemon = build(:pokemon, sp_defense: 1.1)
+    expect(pokemon).to be_invalid
+
+    pokemon = build(:pokemon, sp_defense: 1)
+    expect(pokemon).to be_valid
+  end
+
+  it 'must have integer speed' do
+    pokemon = build(:pokemon, speed: 'Speed')
+    expect(pokemon).to be_invalid
+
+    pokemon = build(:pokemon, speed: 1.1)
+    expect(pokemon).to be_invalid
+
+    pokemon = build(:pokemon, speed: 1)
+    expect(pokemon).to be_valid
+  end
 end

--- a/spec/models/pokemon_spec.rb
+++ b/spec/models/pokemon_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Pokemon, type: :model do
 
     pokemon = build(:pokemon, height: 1)
     expect(pokemon).to be_valid
-    
+
     pokemon = build(:pokemon, height: 1.1)
     expect(pokemon).to be_valid
   end
@@ -50,7 +50,7 @@ RSpec.describe Pokemon, type: :model do
 
     pokemon = build(:pokemon, weight: 1)
     expect(pokemon).to be_valid
-    
+
     pokemon = build(:pokemon, weight: 1.1)
     expect(pokemon).to be_valid
   end
@@ -83,7 +83,7 @@ RSpec.describe Pokemon, type: :model do
 
     pokemon = build(:pokemon, male_gender_ratio: 1)
     expect(pokemon).to be_valid
-    
+
     pokemon = build(:pokemon, male_gender_ratio: 1.1)
     expect(pokemon).to be_valid
   end


### PR DESCRIPTION
This PR adds models validations to Pokemon and AlolaForm models along with its specs to ensure the validations are working properly.

Also adds a new rule to .editorconfig to trim trailing whitespaces. RuboCop was complaining about that in some files and this will solve it for us automatically.