### PR TITLE
Update seeds.rb to load files from db/seeds

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,3 +1,14 @@
+# insert in the array below the name of the files that must be loaded when seeding the database
+# files must be inside RAILS_ROOT/db/seeds/ folder
+# they will be loaded in the order they are inside the array
+seed_files = \
+[]
+
+seed_files.each do |file|
+  absolute_filename = File.join(Rails.root, 'db', 'seeds', file)
+  load absolute_filename if File.exist?(absolute_filename)
+end
+
 # Pokémon types ---------------------------------------------------------------------------------------------
 
 bug      = Type.create!(name: 'Bug')


### PR DESCRIPTION
This PR prepares seeds.rb to load files from db/seeds folder so we can have seeds more organized.

All filenames must be put inside the array `seed_files` and everything else will work automatically.

An example:
```ruby
seed_files = \
[
  'types.rb',
  'moves.rb'
]
```

Please notice that the order the names are put in the array matters.