### PR TITLE
Add simplecov filters

### DIFF
--- a/spec/support/simplecov.rb
+++ b/spec/support/simplecov.rb
@@ -1,2 +1,8 @@
 require 'simplecov'
-SimpleCov.start 'rails'
+
+SimpleCov.start 'rails' do
+  add_filter '/app/jobs/application_job.rb'
+  add_filter '/app/channels/application_cable/channel.rb'
+  add_filter '/app/channels/application_cable/connection.rb'
+  add_filter '/app/mailers/application_mailer.rb'
+end


### PR DESCRIPTION
This PR adds some filters to simplecov to ignore some files that we are not using and are not going to use either.

These files are:
`app/jobs/application_job.rb`
`app/channels/application_cable/channel.rb`
`app/channels/application_cable/connection.rb`
`app/mailers/application_mailer.rb`